### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/checkers/exception2And9.go
+++ b/checkers/exception2And9.go
@@ -4,7 +4,7 @@ import (
 	m "github.com/AntoineAugusti/moduluschecking/models"
 )
 
-// Get weights to use for a bank account following the exception 2 or 9.
+// WeightsForException2Or9 gets weights to use for a bank account following the exception 2 or 9.
 func WeightsForException2Or9(b m.BankAccount, sc m.SortCodeData) (weights []int) {
 	if !(sc.IsException(2) || sc.IsException(9)) {
 		panic("Expected exception 2 or exception 9 sort code")

--- a/checkers/exception3.go
+++ b/checkers/exception3.go
@@ -4,7 +4,7 @@ import (
 	m "github.com/AntoineAugusti/moduluschecking/models"
 )
 
-// Check if we follow the criteria of the exception 3
+// FollowsException3 checks if we follow the criteria of the exception 3
 func FollowsException3(b m.BankAccount, scData m.SortCodeData) bool {
 	c := b.NumberAtPosition("c")
 

--- a/checkers/generalChecker.go
+++ b/checkers/generalChecker.go
@@ -18,7 +18,7 @@ func (e GeneralChecker) IsValid(b m.BankAccount, sc m.SortCodeData, attempt int)
 	return e.RemainderFromRegularCheck(b, sc) == 0
 }
 
-// Get the remainder of the check
+// RemainderFromRegularCheck gets the remainder of the check
 func (e GeneralChecker) RemainderFromRegularCheck(b m.BankAccount, scData m.SortCodeData) int {
 	switch {
 	case scData.Algorithm == "DBLAL":

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -14,13 +14,13 @@ func AddDigits(nb int) int {
 	return nb%10 + nb/10
 }
 
-// Add leading zeros to a number to have a string
+// AddLeadingZerosToNumber adds leading zeros to a number to have a string
 // of length 6
 func AddLeadingZerosToNumber(nb int) string {
 	return AddLeadingZeros(strconv.Itoa(nb), 6)
 }
 
-// Add leading zeros to a string to have a string
+// AddLeadingZeros adds leading zeros to a string to have a string
 // of a desired length
 func AddLeadingZeros(s string, desiredLength int) string {
 	for len(s) < desiredLength {
@@ -58,7 +58,7 @@ func StringSliceToIntSlice(slice []string) (res []int) {
 	return res
 }
 
-// Remove dashes from a string
+// RemoveDashes removes dashes from a string
 func RemoveDashes(s string) string {
 	return strings.Replace(s, "-", "", -1)
 }

--- a/models/bankAccount.go
+++ b/models/bankAccount.go
@@ -26,7 +26,7 @@ func (b BankAccount) MergeAccountDetails() []int {
 	return append(b.SortCodeSlice(), b.AccountNumberSlice()...)
 }
 
-// Get the integer value from a letter, according to the defined code:
+// NumberAtPosition gets the integer value from a letter, according to the defined code:
 // Letters between u and z select a digit from the sort code
 // Letters between a and h select a digit from the account number
 func (b BankAccount) NumberAtPosition(letter string) int {

--- a/models/sortCodeData.go
+++ b/models/sortCodeData.go
@@ -17,22 +17,22 @@ type SortCodeData struct {
 	LineNumber int
 }
 
-// Does this sort code has got an exception?
+// HasException Does this sort code has got an exception?
 func (s SortCodeData) HasException() bool {
 	return s.ExceptionValue > 0
 }
 
-// Does this sort code follows another rule?
+// HasNext Does this sort code follows another rule?
 func (s SortCodeData) HasNext() bool {
 	return s.Next != nil
 }
 
-// Check if a sort code follows an exception.
+// IsException checks if a sort code follows an exception.
 func (s SortCodeData) IsException(exceptionValue int) bool {
 	return s.HasException() && s.ExceptionValue == exceptionValue
 }
 
-// Check if a sort code follows 2 exceptions.
+// FollowsExceptions checks if a sort code follows 2 exceptions.
 func (s SortCodeData) FollowsExceptions(ex1, ex2 int) bool {
 	is1 := s.IsException(ex1)
 	has2 := s.HasNext() && s.Next.IsException(ex2)

--- a/models/sortCodeRange.go
+++ b/models/sortCodeRange.go
@@ -20,7 +20,7 @@ type SortCodeRange struct {
 	LineNumber int
 }
 
-// Check if a sort code range has got an exception
+// HasException checks if a sort code range has got an exception
 func (sc SortCodeRange) HasException() bool {
 	return sc.ExceptionValue > 0
 }

--- a/parsers/fileParser.go
+++ b/parsers/fileParser.go
@@ -28,7 +28,7 @@ type FileParser struct {
 	weights map[string]m.SortCodeData
 }
 
-// Get all known sort code substitutions.
+// Substitutions gets all known sort code substitutions.
 func (fp FileParser) Substitutions() map[string]string {
 	substitutions := make(map[string]string)
 
@@ -44,7 +44,7 @@ func (fp FileParser) Substitutions() map[string]string {
 	return substitutions
 }
 
-// Get the weights, exception information and algorithm to use for all known sort codes.
+// Weights gets the weights, exception information and algorithm to use for all known sort codes.
 func (fp FileParser) Weights() map[string]m.SortCodeData {
 	jobs := make(chan LineRecord)
 	results := make(chan m.SortCodeRange)

--- a/resolvers/resolver.go
+++ b/resolvers/resolver.go
@@ -14,7 +14,7 @@ type Resolver struct {
 	exceptionCheckers map[int]m.Checker
 }
 
-// Check if a bank account number is valid
+// IsValid checks if a bank account number is valid
 func (r Resolver) IsValid(b m.BankAccount) bool {
 	scData := r.weights[b.SortCode]
 	secondCheck := true


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?